### PR TITLE
Fix indentation in PHP files and add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# 2 space indentation for JS, it's common
+[*.js]
+indent_style = space
+indent_size = 2
+
+# Tab indentation for PHP
+[*.php]
+indent_style = tab

--- a/includes/admin/wanderlist-settings.php
+++ b/includes/admin/wanderlist-settings.php
@@ -12,8 +12,10 @@
  */
 
 /*
- * Add our settings page as a submenu of our existing "Wanderlist" menu, created by the "location" CPT.
- * This means all behaviours for the plugin will be clustered under a single, logical menu.
+ * Add our settings page as a submenu of our existing "Wanderlist" menu, created
+ * by the "location" CPT.
+ * This means all behaviours for the plugin will be clustered under a single,
+ * logical menu.
  */
 function wanderlist_add_admin_menu() {
 	add_submenu_page(
@@ -137,13 +139,13 @@ add_action( 'admin_init', 'wanderlist_settings_init' );
  * These functions add descriptions for each of our settings sections.
  */
 function wanderlist_mapbox_section_description() {
-		printf(
-			wp_kses( __( '<a href="%1$s">Sign up for a free Mapbox account here</a>. Generate a new <strong>public</strong> API key from <a href="%2$s">Account → Apps</a> and enter it below.', 'wanderlist' ),
-				array( 'a' => array( 'href' => array() ) )
-			),
-			esc_url( 'https://www.mapbox.com/signup/' ),
-			esc_url( 'https://www.mapbox.com/account/apps/' )
-		);
+	printf(
+		wp_kses( __( '<a href="%1$s">Sign up for a free Mapbox account here</a>. Generate a new <strong>public</strong> API key from <a href="%2$s">Account → Apps</a> and enter it below.', 'wanderlist' ),
+			array( 'a' => array( 'href' => array() ) )
+		),
+		esc_url( 'https://www.mapbox.com/signup/' ),
+		esc_url( 'https://www.mapbox.com/account/apps/' )
+	);
 }
 
 function wanderlist_general_section_description() {
@@ -198,7 +200,7 @@ function wanderlist_dateformat_render() {
 			array(
 				'a' => array( 'href' => array() ),
 				'br' => array(),
-				)
+			)
 		),
 		esc_url( 'https://codex.wordpress.org/Formatting_Date_and_Time' )
 	);

--- a/includes/public/wanderlist-public.php
+++ b/includes/public/wanderlist-public.php
@@ -36,16 +36,16 @@ function wanderlist_get_current_location( $output = 'simple' ) {
 		'posts_per_page' => 1,
 		'post_type'      => 'wanderlist-location',
 		'meta_query'     => array(
-								array(
-									'key'     => 'wanderlist-arrival-date',
-									'value'   => wanderlist_today(),
-									'compare' => '<=',
-								),
-								array(
-									'key'     => 'wanderlist-departure-date',
-									'value'   => wanderlist_today(),
-									'compare' => '>=',
-								),
+			array(
+				'key'     => 'wanderlist-arrival-date',
+				'value'   => wanderlist_today(),
+				'compare' => '<=',
+			),
+			array(
+				'key'     => 'wanderlist-departure-date',
+				'value'   => wanderlist_today(),
+				'compare' => '>=',
+			),
 		),
 	) );
 	// If we didn't find a current location, output our current home location
@@ -84,24 +84,24 @@ function wanderlist_get_home( $date, $output = 'title' ) {
 	$homes = get_posts( array(
 		'posts_per_page' => 1,
 		'post_type'      => 'wanderlist-location',
-		'tax_query'      => array(
-							array(
-								'taxonomy' => 'post_tag',
-								'field'    => 'term_id',
-								'terms'    => $options['wanderlist_home_tag'],
-								'operator' => 'IN',
-							),
-						),
-		'meta_query'     => array(
-								array(
-									'key'     => 'wanderlist-arrival-date',
-									'value'   => $date,
-									'compare' => '<=',
-								),
-		),
 		'orderby'        => 'meta_value post_date',
 		'meta_key'       => 'wanderlist-arrival-date',
 		'order'          => $order,
+		'tax_query'      => array(
+			array(
+				'taxonomy' => 'post_tag',
+				'field'    => 'term_id',
+				'terms'    => $options['wanderlist_home_tag'],
+				'operator' => 'IN',
+			),
+		),
+		'meta_query'     => array(
+			array(
+				'key'     => 'wanderlist-arrival-date',
+				'value'   => $date,
+				'compare' => '<=',
+			),
+		),
 	) );
 
 	// Show our most recent location tagged "home"
@@ -164,13 +164,13 @@ function wanderlist_list_locations( $limit = null, $show = 'default' ) {
 		'meta_compare'   => $compare,
 		'order'          => $order,
 		'tax_query'      => array(
-							array(
-								'taxonomy' => 'post_tag',
-								'field'    => 'term_id',
-								'terms'    => $options['wanderlist_home_tag'],
-								'operator' => 'NOT IN',
-							),
-						),
+			array(
+				'taxonomy' => 'post_tag',
+				'field'    => 'term_id',
+				'terms'    => $options['wanderlist_home_tag'],
+				'operator' => 'NOT IN',
+			),
+		),
 	);
 
 	$location_query = new WP_Query( $args );
@@ -332,22 +332,22 @@ function wanderlist_date( $post, $type ) {
 		// Are our months and years the same?
 		elseif ( $arrival_month === $departure_month  && $arrival_year === $departure_year ) :
 			$formatted_date = date( 'F j', strtotime( $arrival_date ) )
-							. '&ndash;'
-							. date( 'j', strtotime( $departure_date ) )
-							. date( ' Y', strtotime( $departure_date ) );
+				. '&ndash;'
+				. date( 'j', strtotime( $departure_date ) )
+				. date( ' Y', strtotime( $departure_date ) );
 
 		// If only the years are the same....
 		elseif ( $arrival_year === $departure_year ) :
 			$formatted_date = date( 'F j', strtotime( $arrival_date ) )
-			 				. '&ndash;'
-							. date( 'F j', strtotime( $departure_date ) )
-							. date( ' Y', strtotime( $departure_date ) );
+				. '&ndash;'
+				. date( 'F j', strtotime( $departure_date ) )
+				. date( ' Y', strtotime( $departure_date ) );
 
 		// Otherwise, just show the full date
 		else:
 			$formatted_date = date( 'F j Y', strtotime( $arrival_date ) )
-			 				. '&ndash;'
-							. date( 'F j Y', strtotime( $departure_date ) );
+				. '&ndash;'
+				. date( 'F j Y', strtotime( $departure_date ) );
 		endif;
 
 	// If nothing is specified, return the arrival date
@@ -559,11 +559,7 @@ function wanderlist_show_map( $overlay = null ) {
 function wanderlist_trip_join( $wp_join ) {
 	if ( is_tax( 'wanderlist-trip' ) ) :
 		global $wpdb;
-		$wp_join .= " LEFT JOIN (
-        SELECT post_id, meta_value as arrival_date
-        FROM $wpdb->postmeta
-        WHERE meta_key =  'wanderlist-arrival-date' ) AS PLACE
-        ON $wpdb->posts.ID = PLACE.post_id ";
+		$wp_join .= " LEFT JOIN (SELECT post_id, meta_value as arrival_date FROM $wpdb->postmeta WHERE meta_key =  'wanderlist-arrival-date' ) AS PLACE ON $wpdb->posts.ID = PLACE.post_id ";
 	endif;
 	return $wp_join;
 }

--- a/includes/public/wanderlist-shortcodes.php
+++ b/includes/public/wanderlist-shortcodes.php
@@ -115,13 +115,14 @@ function wanderlist_overview_shortcode( $atts, $content = null  ) {
 	$widgets[] = array(
 		'class'   => 'wanderlist-number-widget',
 		'title'   => esc_html__( 'Stats', 'wanderlist' ),
-		'content' => '<div class="wanderlist-place-count"><span class="wanderlist-number">' . wanderlist_count( 'places' ) .
-					'</span><span class="wanderlist-item">'. esc_html__( 'Places', 'wanderlist' ) . '</span></div>
-					<span class="wanderlist-connector">' . esc_html__( 'in', 'wanderlist' ) . '</span>
-		         <div class="wanderlist-country-count"><span class="wanderlist-number">' . wanderlist_count( 'countries' ) .
-				 	'</span><span class="wanderlist-item">'. esc_html__( 'Countries', 'wanderlist' ) . '</span></div>
-					<span class="wanderlist-connector">' . esc_html__( 'on', 'wanderlist' ) . '</span>
-		         <div class="wanderlist-continent-count"><span class="wanderlist-number">' . wanderlist_count( 'continents' ). '</span><span class="wanderlist-item">'. esc_html__( 'Continents', 'wanderlist' ) . '</span></div>',
+		'content' => '<div class="wanderlist-place-count">' .
+			'<span class="wanderlist-number">' . wanderlist_count( 'places' ) .
+			'</span><span class="wanderlist-item">'. esc_html__( 'Places', 'wanderlist' ) . '</span></div>
+			<span class="wanderlist-connector">' . esc_html__( 'in', 'wanderlist' ) . '</span>
+			<div class="wanderlist-country-count"><span class="wanderlist-number">' . wanderlist_count( 'countries' ) .
+			'</span><span class="wanderlist-item">'. esc_html__( 'Countries', 'wanderlist' ) . '</span></div>
+			<span class="wanderlist-connector">' . esc_html__( 'on', 'wanderlist' ) . '</span>
+			<div class="wanderlist-continent-count"><span class="wanderlist-number">' . wanderlist_count( 'continents' ). '</span><span class="wanderlist-item">'. esc_html__( 'Continents', 'wanderlist' ) . '</span></div>',
 	);
 
 	$return = '<div class="wanderlist-overview">';

--- a/includes/public/wanderlist-templates.php
+++ b/includes/public/wanderlist-templates.php
@@ -58,7 +58,8 @@ add_filter( 'single_template', 'wanderlist_CPT_template' );
 
 /**
  * Check to see if our theme has custom templates available.
- * This check is used by the above functions to see if we should use the fallback functions
+ * This check is used by the above functions to see if we should use the
+ * fallback functions
  */
 function wanderlist_is_template( $template_path, $match ){
 	// Check for template taxonomy-wanderlist-trip.php or taxonomy-wanderlist-trip-{term-slug}.php

--- a/includes/wanderlist-activator.php
+++ b/includes/wanderlist-activator.php
@@ -87,8 +87,10 @@ function wanderlist_custom_data() {
 
 	/**
 	* Register a taxonomy for trips, so we can map out a particular trip.
-	* This just allows us an easy way to group locations and travels into different trips.
-	* At some point, we'll add functionality to show full details of a particular trip.
+	* This just allows us an easy way to group locations and travels into
+	* different trips.
+	* At some point, we'll add functionality to show full details of a
+	* particular trip.
 	*/
 	$trip_labels = array(
 		'name'                       => _x( 'Trips', 'Taxonomy General Name', 'wanderlist' ),
@@ -123,8 +125,10 @@ function wanderlist_custom_data() {
 add_action( 'init', 'wanderlist_custom_data' );
 
 /*
- * On activation, create a new page called "travels" to show an overview of user's travels.
- * @todo: Delete this page, and menu item, on uninstall, check for binned page maybe, serialise db options
+ * On activation, create a new page called "travels" to show an overview of
+ * user's travels.
+ * @todo: Delete this page, and menu item, on uninstall, check for binned page
+ * maybe, serialise db options
  */
 function wanderlist_landing_page() {
 
@@ -163,32 +167,32 @@ function wanderlist_landing_page() {
  * Adds specified page to the primary menu.
  * This tries to be smart about finding the "primary menu", but isn't anywhere
  * close to foolproof, and requires that a menu location be set already.
- * At some point, this may warrant further investigation, but it's pretty low priority.
+ * At some point, this may warrant further investigation, but it's pretty low
+ * priority.
  */
 function wanderlist_add_menu_item( $post_id ) {
-  // First, let's get a menu. We'll make a new one if we don't already have any,
-  // but otherwise we'll just use the most logical-seeming menu.
-  $locations = get_nav_menu_locations();
-  if ( ! $locations ) :
-	  $menu_id = wp_create_nav_menu ( 'Primary Menu' );
-  elseif ( $locations['primary'] ) :
-	  $menu_id = $locations['primary'];
-  else :
-	  $menu_id = $locations[0];
-  endif;
+	// First, let's get a menu. We'll make a new one if we don't already have any,
+	// but otherwise we'll just use the most logical-seeming menu.
+	$locations = get_nav_menu_locations();
+	if ( ! $locations ) :
+		$menu_id = wp_create_nav_menu ( 'Primary Menu' );
+	elseif ( $locations['primary'] ) :
+		$menu_id = $locations['primary'];
+	else :
+		$menu_id = $locations[0];
+	endif;
 
-  // Add page to our selected menu
-  $new_menu_item_id = wp_update_nav_menu_item ( $menu_id, 0, array(
-	  'menu-item-title'     => esc_html__( 'Travels', 'wanderlist' ),
-	  'menu-item-object'    => 'page',
-	  'menu-item-type'      => 'post_type',
-	  'menu-item-object-id' => $post_id,
-	  'menu-item-status'    => 'publish',
-	  )
-  );
+	// Add page to our selected menu
+	$new_menu_item_id = wp_update_nav_menu_item ( $menu_id, 0, array(
+		'menu-item-title'     => esc_html__( 'Travels', 'wanderlist' ),
+		'menu-item-object'    => 'page',
+		'menu-item-type'      => 'post_type',
+		'menu-item-object-id' => $post_id,
+		'menu-item-status'    => 'publish',
+	) );
 
-  // Save the id in the database, so we can delete it on de-activation
-  update_option( 'wanderlist_menu_item', $new_menu_item_id );
+	// Save the id in the database, so we can delete it on de-activation
+	update_option( 'wanderlist_menu_item', $new_menu_item_id );
 }
 
 /*

--- a/includes/wanderlist.php
+++ b/includes/wanderlist.php
@@ -9,8 +9,9 @@
  */
 
 /**
- * This is a reusable function that allows us to grab place-specific data and return
- * it in a consistent way across our plugin scripts, and in theme template files as well.
+ * This is a reusable function that allows us to grab place-specific data and
+ * return it in a consistent way across our plugin scripts, and in theme
+ * template files as well.
  */
 function wanderlist_place_data( $data, $post_ID = null ) {
 	switch ( $data ) {


### PR DESCRIPTION
This fixes a few stray mixed tab/spaces issues and moves all PHP files to tabs.
It fixes some over line-length function comments too.

If you install the editorconfig package for Atom, this should fix any
errors in new PHP files using the wrong kinds of tabs.
